### PR TITLE
Feat/dfa

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,15 +30,19 @@ module.exports = function camunda() {
                     parseResponse: false,
                     body: rest
                 }),
-                'camunda.process.start.request.send': ({process, ...rest}) => ({
-                    key: process,
-                    body: {
-                        variables: Object.entries(rest).reduce((prev, [name, value]) => {
-                            prev[name] = typeof value === 'object' ? value : {value};
-                            return prev;
-                        }, {})
-                    }
-                })
+                'camunda.process.start.request.send': ({process, ...rest}) => {
+                    const variables = Object.entries(rest).reduce((prev, [name, value]) => {
+                        prev[name] = typeof value === 'object' ? {value: JSON.stringify(value)} : {value};
+                        return prev;
+                    }, {});
+
+                    return {
+                        key: process,
+                        body: {
+                            variables
+                        }
+                    };
+                }
             };
         }
     };

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function camunda() {
                     parseResponse: false,
                     body: rest
                 }),
-                'camunda.task.complete.request.send': ({id, ...rest}) => ({
+                'camunda.externaltask.complete.request.send': ({id, ...rest}) => ({
                     id,
                     parseResponse: false,
                     body: rest
@@ -61,6 +61,32 @@ module.exports = function camunda() {
                             return prev;
                         }
                     }, {});
+                },
+                'camunda.task.claim.request.send': ({id, ...rest}) => ({
+                    id,
+                    parseResponse: false,
+                    body: rest
+                }),
+                'camunda.task.unclaim.request.send': ({id}) => ({
+                    id,
+                    parseResponse: false
+                }),
+                'camunda.task.complete.request.send': ({id, variables = {}}) => {
+                    const transformedVars = Object.entries(variables).reduce((prev, [key, value]) => {
+                        const variableType = typeof value;
+                        prev[key] = {
+                            value: variableType === 'object' ? JSON.stringify(value) : value,
+                            type: variableType === 'object' ? 'string' : variableType
+                        };
+                        return prev;
+                    }, {});
+                    return {
+                        id,
+                        parseResponse: false,
+                        body: {
+                            variables: transformedVars
+                        }
+                    };
                 }
             };
         }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function camunda() {
                     camunda: [require.resolve('./swagger')]
                 },
                 mergeOptions: {
-                    mergeStragegies: {
+                    mergeStrategies: {
                         'openApi.camunda': 'combine'
                     }
                 }

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ module.exports = function camunda() {
 
         handlers() {
             return {
-                receive: response => {
-                    if (response.code !== 200) return response.body;
+                receive: (response, {mtid}) => {
+                    if (mtid === 'error') return response.body;
                     return response.payload;
                 },
                 send: params => ({
@@ -44,9 +44,9 @@ module.exports = function camunda() {
                         }
                     };
                 },
-                'camunda.variables.get.request.receive': response => {
-                    if (response.code !== 200) return response.body;
-                    return response.body.payload && Object.entries(response.body.payload).reduce((prev, [name, value]) => {
+                'camunda.variables.get.response.receive': (response, {mtid}) => {
+                    if (mtid === 'error') return response.body;
+                    return response.payload && Object.entries(response.payload).reduce((prev, [name, value]) => {
                         try {
                             const actualValue = JSON.parse(value.value);
                             prev[name] = typeof actualValue === 'object' ? actualValue : value.value;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 module.exports = function camunda() {
     return class camunda extends require('ut-port-http')(...arguments) {
         get defaults() {
@@ -8,8 +10,29 @@ module.exports = function camunda() {
                 },
                 openApi: {
                     camunda: require.resolve('./swagger')
-                }
+                },
+                host: 'camunda.k8s.softwaregroup-bg.com',
+                basePath: '/engine-rest/engine/default'
             };
+        }
+
+        init() {
+            try {
+                if (
+                    typeof this.config.openApi.camunda === 'string' &&
+                    !this.config.openApi.camunda.startsWith('http')
+                ) {
+                    const apiJson = JSON.parse(
+                        fs.readFileSync(this.config.openApi.camunda, 'utf-8')
+                    );
+                    if (apiJson.swagger) {
+                        apiJson.host = this.config.host;
+                        apiJson.basePath = this.config.basePath;
+                        this.config.openApi.camunda = apiJson;
+                    }
+                }
+            } catch (e) {}
+            return super.init(...arguments);
         }
 
         handlers() {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 module.exports = function camunda() {
     return class camunda extends require('ut-port-http')(...arguments) {
         get defaults() {
@@ -9,30 +7,14 @@ module.exports = function camunda() {
                     json: true
                 },
                 openApi: {
-                    camunda: require.resolve('./swagger')
+                    camunda: [require.resolve('./swagger')]
                 },
-                host: 'camunda.k8s.softwaregroup-bg.com',
-                basePath: '/engine-rest/engine/default'
-            };
-        }
-
-        init() {
-            try {
-                if (
-                    typeof this.config.openApi.camunda === 'string' &&
-                    !this.config.openApi.camunda.startsWith('http')
-                ) {
-                    const apiJson = JSON.parse(
-                        fs.readFileSync(this.config.openApi.camunda, 'utf-8')
-                    );
-                    if (apiJson.swagger) {
-                        apiJson.host = this.config.host;
-                        apiJson.basePath = this.config.basePath;
-                        this.config.openApi.camunda = apiJson;
+                mergeOptions: {
+                    mergeStragegies: {
+                        'openApi.camunda': 'combine'
                     }
                 }
-            } catch (e) {}
-            return super.init(...arguments);
+            };
         }
 
         handlers() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-camunda",
-  "version": "7.0.4-dfa.2",
+  "version": "7.0.4-dfa.3",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-camunda",
-  "version": "7.0.4-dfa.3",
+  "version": "7.0.4-dfa.4",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-camunda",
-  "version": "7.0.4-dfa.1",
+  "version": "7.0.4-dfa.2",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-camunda",
-  "version": "7.0.4-dfa.4",
+  "version": "7.0.4-dfa.5",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-camunda",
-  "version": "7.0.4-dfa.0",
+  "version": "7.0.4-dfa.1",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-port-camunda",
-  "version": "7.0.3",
+  "version": "7.0.4-dfa.0",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {

--- a/swagger.json
+++ b/swagger.json
@@ -10677,7 +10677,7 @@
         "tags" : [ "Task" ],
         "summary" : "Retrieves the number of tasks that fulfill a provided filter.",
         "description" : "Retrieves the number of tasks that fulfill a provided filter. Corresponds to the size of the result set when using the Get Tasks method.There are several query parameters (such as `assigneeExpression`) for specifying an EL expression. These are disabled by default to prevent remote code execution. See the section on security considerations for custom code in the user guide for details.",
-        "operationId" : "getTasksCount",
+        "operationId" : "task.count",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "assigneeExpression",

--- a/swagger.json
+++ b/swagger.json
@@ -10524,6 +10524,21 @@
           "required" : false,
           "type" : "string"
         }, {
+          "name": "candidateGroups",
+          "in": "query",
+          "type": "string",
+          "description": "Restrict to tasks that are offered to any of the given candidate groups. Takes a\ncomma-separated list of group names, so for example `developers,support,sales`."
+        }, {
+            "name": "taskVariables",
+            "in": "query",
+            "type": "string",
+            "description": "Only include tasks that have variables with certain values. Variable filtering\nexpressions are comma-separated and are structured as follows:\n\nA valid parameter value has the form `key_operator_value`. `key` is the variable name,\n`operator` is the comparison operator to be used and `value` the variable value.\n\n**Note**: Values are always treated as String objects on server side.\n\nValid `operator` values are:\n`eq` - equal to;\n`neq` - not equal to;\n`gt` - greater than;\n`gteq` - greater than or equal to;\n`lt` - lower than;\n`lteq` - lower than or equal to;\n`like`.\n`key` and `value` may not contain underscore or comma characters."
+          }, {
+            "name": "processVariables",
+            "in": "query",
+            "type": "string",
+            "description": "Only include tasks that belong to process instances that have variables with certain \nvalues. Variable filtering expressions are comma-separated and are structured as\nfollows:\n\nA valid parameter value has the form `key_operator_value`. `key` is the variable name,\n`operator` is the comparison operator to be used and `value` the variable value.\n\n**Note**: Values are always treated as String objects on server side.\n\nValid `operator` values are:\n`eq` - equal to;\n`neq` - not equal to;\n`gt` - greater than;\n`gteq` - greater than or equal to;\n`lt` - lower than;\n`lteq` - lower than or equal to;\n`like`.\n`key` and `value` may not contain underscore or comma characters."
+          }, {
           "name" : "processDefinitionKeyIn",
           "in" : "query",
           "description" : "Restrict to tasks that belong to a process definition with one of the given keys. The keys need to be in a comma-separated list.",
@@ -10625,7 +10640,17 @@
           "description" : "Sort the results in a given order. Values may be asc for ascending order or desc for descending order. Must be used in conjunction with the sortBy parameter.",
           "required" : false,
           "type" : "string"
-        }],
+        }, {
+          "name": "createdAfter",
+          "in": "query",
+          "type": "string",
+          "description": "Restrict to tasks that were created after the given date. By\n[default](https://docs.camunda.org/manual/7.13/reference/rest/overview/date-format/), the date must have the\nformat `yyyy-MM-dd\u0027T\u0027HH:mm:ss.SSSZ`, e.g., `2013-01-23T14:42:45.342+0200`."
+        }, {
+          "name": "createdBefore",
+          "in": "query",
+          "type": "string",
+          "description": "Restrict to tasks that were created before the given date. By\n[default](https://docs.camunda.org/manual/7.13/reference/rest/overview/date-format/), the date must have the\nformat `yyyy-MM-dd\u0027T\u0027HH:mm:ss.SSSZ`, e.g., `2013-01-23T14:42:45.332+0200`."
+        } ],
         "responses" : {
           "200" : {
             "description" : "Request successful. In case of an expected HAL response.",

--- a/swagger.json
+++ b/swagger.json
@@ -11003,7 +11003,7 @@
         "tags" : [ "Task" ],
         "summary" : "Retrieves a task by id.",
         "description" : "Retrieves a task by id.",
-        "operationId" : "getTask",
+        "operationId" : "task.get",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
@@ -12006,7 +12006,7 @@
         "tags" : [ "Task" ],
         "summary" : "Retrieves all variables visible from the task.",
         "description" : "Retrieves all variables visible from the task. A variable is visible from the task if it is a local task variable or declared in a parent scope of the task. See documentation on visiblity of variables.",
-        "operationId" : "getVariables",
+        "operationId" : "variables.get",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",

--- a/swagger.json
+++ b/swagger.json
@@ -10613,7 +10613,19 @@
           "description" : "Only include tasks that the given user is involved in. A user is involved in a task if an identity link exists between task and user (e.g., the user is the assignee).",
           "required" : false,
           "type" : "string"
-        } ],
+        }, {
+          "name" : "sortBy",
+          "in" : "query",
+          "description" : "Sort the results lexicographically by a given criterion. Valid values are instanceId, caseInstanceId, dueDate, executionId, caseExecutionId,assignee, created, description, id, name, nameCaseInsensitive and priority. Must be used in conjunction with the sortOrder parameter.",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "sortOrder",
+          "in" : "query",
+          "description" : "Sort the results in a given order. Values may be asc for ascending order or desc for descending order. Must be used in conjunction with the sortBy parameter.",
+          "required" : false,
+          "type" : "string"
+        }],
         "responses" : {
           "200" : {
             "description" : "Request successful. In case of an expected HAL response.",
@@ -10895,7 +10907,7 @@
           "description" : "Only include tasks that the given user is involved in. A user is involved in a task if an identity link exists between task and user (e.g., the user is the assignee).",
           "required" : false,
           "type" : "string"
-        } ],
+        }],
         "responses" : {
           "200" : {
             "description" : "Request successful.",

--- a/swagger.json
+++ b/swagger.json
@@ -4876,7 +4876,7 @@
         "tags" : [ "External" ],
         "summary" : "Completes an external task by id and updates process variables.",
         "description" : "Completes an external task by id and updates process variables.",
-        "operationId" : "task.complete",
+        "operationId" : "externaltask.complete",
         "consumes" : [ "application/json" ],
         "parameters" : [ {
           "in" : "body",
@@ -11267,7 +11267,7 @@
         "tags" : [ "Task" ],
         "summary" : "Claims a task for a specific user.",
         "description" : "Claims a task for a specific user.Note: The difference with the Set Assignee method is that here a check is performed to see if the task already has a user assigned to it.",
-        "operationId" : "claim",
+        "operationId" : "task.claim",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -11396,7 +11396,7 @@
         "tags" : [ "Task" ],
         "summary" : "Completes a task and updates process variables.",
         "description" : "Completes a task and updates process variables.",
-        "operationId" : "complete",
+        "operationId" : "task.complete",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
@@ -11982,7 +11982,7 @@
         "tags" : [ "Task" ],
         "summary" : "Resets a task's assignee.",
         "description" : "Resets a task's assignee. If successful, the task is not assigned to a user.",
-        "operationId" : "unclaim",
+        "operationId" : "task.unclaim",
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",


### PR DESCRIPTION
1. Allow merge of configs to overwrite swagger props.
2. In the receive method, if its error pass it to the consumers.
3. In send spread the params so they are mapped to query params.
4. Change task to externalTask.
5. Parse variables from values to camunda's model.
6. Claim/Unclaim tasks with body(info for the user).
7. Complete task and pass any variables from method to Camunda process.