### PR TITLE
feat: expose message.send operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "sort-keys": "2.0.0",
     "tap": "^12.5.3",
     "ut-tools": "^6.29.12"
   },

--- a/swagger.json
+++ b/swagger.json
@@ -7208,7 +7208,7 @@
         "tags" : [ "Message" ],
         "summary" : "Correlates a message to the process engine to either trigger a message start event or an intermediate message catching event.",
         "description" : "Correlates a message to the process engine to either trigger a message start event or an intermediate message catching event. Internally this maps to the engine's message correlation builder methods `MessageCorrelationBuilder#correlateWithResult()` and `MessageCorrelationBuilder#correlateAllWithResult()`. For more information about the correlation behavior, see the Message Events section of the BPMN 2.0 Implementation Reference.",
-        "operationId" : "deliverMessage",
+        "operationId" : "message.send",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {


### PR DESCRIPTION
camunda.message.send in order to have event listeners in the BPMN diagrams.
for e.g. if eligibility check expires, then Task is automatically reasigned to another user or group.