### PR TITLE
fix: allow candidateGroups filter on task.count

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -10879,6 +10879,11 @@
           "required" : false,
           "type" : "string"
         }, {
+          "name": "candidateGroups",
+          "in": "query",
+          "type": "string",
+          "description": "Restrict to tasks that are offered to any of the given candidate groups. Takes a\ncomma-separated list of group names, so for example `developers,support,sales`."
+        }, {
           "name" : "candidateGroup",
           "in" : "query",
           "description" : "Only include tasks that are offered to the given group.",


### PR DESCRIPTION
latest camunda is 7.15, while swagger.json is for 7.12
could we replace the whole file  and transfer the operationIds instead of adding params on demand?